### PR TITLE
fix a typo in make_pol2expimage

### DIFF
--- a/skymodels2.jl
+++ b/skymodels2.jl
@@ -158,7 +158,7 @@ function make_pol2expimage(ftot, a, b, c, d, mimg)
     δ = VLBISkyModels.PolExp2Map!(a, b, c, d, axisdims(mimg))
     brast = baseimage(δ)
     fI = Comrade._fastsum(brast.I)
-    fr = zero(δI)
+    fr = zero(fI)
     @inbounds for i in eachindex(mimg, brast)
         brast[i] *= mimg[i] / fI
         fr += brast[i].I


### PR DESCRIPTION
There is apparently a typo created in a recent change in `make_pol2expimage` of `skymodels2.jl`. This is a fix for this typo. 